### PR TITLE
Removed all usages of and references to enableHomestead setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Creates a new VM object
 - `opts`
   - `state` - the state trie
   - `blockchain` - an instance of ethereumjs-blockchain
-  - `enableHomestead` - a boolean that overrides the homestead settings based on blocknumber
   - `activatePrecompiles` - create entries in the state tree for the precompiled contracts
 
 ### `VM` methods

--- a/lib/hooked.js
+++ b/lib/hooked.js
@@ -15,9 +15,7 @@ module.exports.fromWeb3Provider = fromWeb3Provider
   this should be made obsolete by a better public API for StateManager
 
   ```js
-  var vm = createHookedVm({
-    enableHomestead: true,
-  }, {
+  var vm = createHookedVm({}, {
     fetchAccountBalance: function(addressHex, cb){ ... },
     fetchAccountNonce: function(addressHex, cb){ ... },
     fetchAccountCode: function(addressHex, cb){ ... },

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,8 +24,6 @@ VM.deps = {
  * @param {Trie} [opts.state] A merkle-patricia-tree instance for the state tree
  * @param {Blockchain} [opts.blockchain] A blockchain object for storing/retrieving blocks
  * @param {Boolean} [opts.activatePrecompiles] Create entries in the state tree for the precompiled contracts
- * @param {Boolean} [opts.enableHomestead] Force enable Homestead irrelevant to block number
- * @param {Boolean} [opts.enableHomesteadReprice] Force enable Homestead Reprice (EIP150) irrevelant to block number
  */
 function VM (opts = {}) {
   this.stateManager = new StateManager({
@@ -67,8 +65,7 @@ VM.prototype.runBlockchain = require('./runBlockchain.js')
 VM.prototype.copy = function () {
   return new VM({
     state: this.trie.copy(),
-    blockchain: this.blockchain,
-    enableHomestead: this.opts.enableHomestead
+    blockchain: this.blockchain
   })
 }
 

--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -42,7 +42,6 @@ module.exports = function (opts, cb) {
   var isCompiled = opts.compiled
   var depth = opts.depth
   var suicides = opts.suicides
-  var enableHomestead = this.opts.enableHomestead === undefined ? block.isHomestead() : this.opts.enableHomestead
   var delegatecall = opts.delegatecall || false
 
   txValue = new BN(txValue)
@@ -158,11 +157,10 @@ module.exports = function (opts, cb) {
           results.gasUsed = totalGas
         } else {
           results.return = new Buffer([])
-          if (enableHomestead) {
-            results.exception = 0
-            err = results.exceptionError = ERROR.OUT_OF_GAS
-            results.gasUsed = gasLimit
-          }
+          // since Homestead
+          results.exception = 0
+          err = results.exceptionError = ERROR.OUT_OF_GAS
+          results.gasUsed = gasLimit
         }
       }
 

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -70,19 +70,15 @@ module.exports = function (opts, cb) {
     origin: opts.origin || opts.caller || utils.zeros(32),
     callData: opts.data || new Buffer([0]),
     code: opts.code,
-    populateCache: opts.populateCache === undefined ? true : opts.populateCache,
-    enableHomestead: this.opts.enableHomestead === undefined ? block.isHomestead() : this.opts.enableHomestead
+    populateCache: opts.populateCache === undefined ? true : opts.populateCache
   }
 
   // temporary - to be factored out
   runState._precompiled = self._precompiled
   runState._vm = self
 
-  if (!runState.enableHomestead) {
-    delete opFns.DELEGATECALL
-  } else {
-    opFns.DELEGATECALL = opFns._DC
-  }
+  // since Homestead
+  opFns.DELEGATECALL = opFns._DC
 
   // prepare to run vm
   preprocessValidJumps(runState)

--- a/tests/BlockchainTestsRunner.js
+++ b/tests/BlockchainTestsRunner.js
@@ -18,8 +18,7 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
   blockchain.ethash.cacheDB = cacheDB
   var vm = new VM({
     state: state,
-    blockchain: blockchain,
-    enableHomestead: true
+    blockchain: blockchain
   })
   var genesisBlock = new Block()
 

--- a/tests/GeneralStateTestsRunner.js
+++ b/tests/GeneralStateTestsRunner.js
@@ -28,8 +28,7 @@ function runTestCase (testData, t, cb) {
   async.series([
     function (done) {
       vm = new VM({
-        state: state,
-        enableHomestead: true
+        state: state
       })
       testUtil.setupPreConditions(state, testData, done)
     },

--- a/tests/hooked.js
+++ b/tests/hooked.js
@@ -31,10 +31,7 @@ tape('hooked-vm', function (test) {
     }
   }
 
-  var vm = createHookedVm({
-    enableHomestead: true,
-    enableHomsteadReprice: true
-  }, hooksForBlockchainState(blockchainState))
+  var vm = createHookedVm({}, hooksForBlockchainState(blockchainState))
 
   // vm.on('step', function(stepData){
   //   console.log(`========================================================`)


### PR DESCRIPTION
Hi, so I removed ``enableHomestead`` everywhere in code, tests and docs in the ``ethereumjs-vm`` repository, this definitely is something which has to be announced prominently in the release notes.

I wasn't sure about the ``isHomestead`` flag in the ``ethereumjs-block`` repo. I came to the conclusion that this remains untouched, is this correct?

For testing I ran all examples from the ``examples`` directory and once again all the state tests, everything worked as expected.

Cheers
Holger

